### PR TITLE
Prevent `JSONException`

### DIFF
--- a/src/give_me_coins/dashboard/GiveMeCoinsWorkerInfo.java
+++ b/src/give_me_coins/dashboard/GiveMeCoinsWorkerInfo.java
@@ -79,7 +79,7 @@ public class GiveMeCoinsWorkerInfo {
 	        hashrate = JSONHelper.getVal(para_workerInfos,"hashrate",0);
 	        if( alive )
 	        {
-	        	last_share_timestamp = JSONHelper.getVal(para_workerInfos,"last_share_timestamp",(long)0);
+	        	last_share_timestamp = JSONHelper.getVal(para_workerInfos, "last_share_timestamp", 0L);
 	        }
 	        else
 	        {

--- a/src/give_me_coins/dashboard/JSONHelper.java
+++ b/src/give_me_coins/dashboard/JSONHelper.java
@@ -136,10 +136,11 @@ public class JSONHelper {
         long retLong = para_defaultValue;
         try
         {
-            retLong =  para_jsonObject.getLong(para_name);
-
+            if (para_jsonObject.has(para_name) && !para_jsonObject.isNull(para_name)) {
+                retLong =  para_jsonObject.getLong(para_name);
+            }
         } catch (JSONException e) {
-            Log.d(TAG, "long json error "+e.toString());
+            Log.d(TAG, "long json error " + e.toString());
         }
         return retLong;
     }


### PR DESCRIPTION
Prevent a `JSONException` from being thrown when unexpected JSON is encountered:

`{"alive":"1","last_share_timestamp":null,"hashrate":"int","username":"String"}`
`{"alive":"1","hashrate":"int","username":"String"}`

This `JSONException` was being caught, and resulted in debug statements being printed to `logcat`:
`D/JSONHelper(xxxxx): long json error org.json.JSONException: No value for last_share_timestamp`
`D/JSONHelper(xxxxx): long json error org.json.JSONException: Value null at last_share_timestamp of type org.json.JSONObject$1 cannot be converted to long`

Here is a stacktrace demonstrating one instance of this issue:
`org.json.JSONException: Value null at last_share_timestamp of type org.json.JSONObject$1 cannot be converted to long
at give_me_coins.dashboard.JSONHelper.getVal(JSONHelper.java:143)
at give_me_coins.dashboard.GiveMeCoinsWorkerInfo.<init>(GiveMeCoinsWorkerInfo.java:82)
at give_me_coins.dashboard.GiveMeCoinsInfo.<init>(GiveMeCoinsInfo.java:102)
at give_me_coins.dashboard.GetInfoWorker.onProgressUpdate(GetInfoWorker.java:150)
at give_me_coins.dashboard.GetInfoWorker.onProgressUpdate(GetInfoWorker.java:23)
at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:647)
.
.
Caused by: org.json.JSONException: Value null at last_share_timestamp of type org.json.JSONObject$1 cannot be converted to long
at org.json.JSON.typeMismatch(JSON.java:100)
at org.json.JSONObject.getLong(JSONObject.java:480)
at give_me_coins.dashboard.JSONHelper.getVal(JSONHelper.java:139)`
